### PR TITLE
年別配当グラフのデータをAPI経由で取得するように変更

### DIFF
--- a/frontend/src/app/yearlyDividend/page.tsx
+++ b/frontend/src/app/yearlyDividend/page.tsx
@@ -16,7 +16,7 @@ interface ChartData {
 }
 
 export default function YearlyDividendChart() {
-    const [chartData, setChartData] = useState({ labels: [], datasets: [] });
+    const [chartData, setChartData] = useState<ChartData | null>(null);
 
     useEffect(() => {
         fetch("http://localhost:8080/api/yearlyDividend")

--- a/frontend/src/app/yearlyDividend/page.tsx
+++ b/frontend/src/app/yearlyDividend/page.tsx
@@ -11,19 +11,17 @@ export default function YearlyDividendChart() {
     const [chartData, setChartData] = useState(null);
 
     useEffect(() => {
-        fetch("/api/yearlyDividend")
-            .then((res) => res.text())  // まずテキストとしてレスポンスを取得
-            .then((text) => {
-                console.log(text);  // レスポンスの内容をログに出力
-                return JSON.parse(text);  // JSONにパース
-            })
-            .then((data) => {
+        fetch("http://localhost:8080/api/yearlyDividend", {
+            credentials: "include", // Cookieを送信（Spring Securityで認証する場合）
+        })
+            .then((res) => res.json())
+            .then((json) => {
                 setChartData({
-                    labels: data.labels,
+                    labels: json.labels.split(","), // サーバー側が文字列を返すならパース
                     datasets: [
                         {
                             label: "配当受取額",
-                            data: data.data,
+                            data: JSON.parse(json.chartData), // 必要に応じてパース
                             backgroundColor: "rgba(0, 0, 255, 0.5)",
                         },
                     ],

--- a/frontend/src/app/yearlyDividend/page.tsx
+++ b/frontend/src/app/yearlyDividend/page.tsx
@@ -15,11 +15,11 @@ useEffect(() => {
         .then((res) => res.json())
         .then((json) => {
             setChartData({
-                labels: json.labels, // そのまま使用
+                labels: json.labels,
                 datasets: [
                     {
                         label: "配当受取額",
-                        data: json.chartData, // そのまま使用
+                        data: json.chartData,
                         backgroundColor: "rgba(0, 0, 255, 0.5)",
                     },
                 ],

--- a/frontend/src/app/yearlyDividend/page.tsx
+++ b/frontend/src/app/yearlyDividend/page.tsx
@@ -45,9 +45,7 @@ export default function YearlyDividendChart() {
                     scales: {
                         y: {
                             ticks: {
-                                callback: function(value) {
-                                    return value + "ドル";
-                                },
+                                callback: (value) => value + "ドル",
                             },
                         },
                     },

--- a/frontend/src/app/yearlyDividend/page.tsx
+++ b/frontend/src/app/yearlyDividend/page.tsx
@@ -25,7 +25,7 @@ export default function YearlyDividendChart() {
                 });
             })
             .catch((error) => {
-                console.error("Error parsing JSON:", error);
+                console.error("データ取得エラー:", error);
             });
     }, []);
 

--- a/frontend/src/app/yearlyDividend/page.tsx
+++ b/frontend/src/app/yearlyDividend/page.tsx
@@ -10,27 +10,25 @@ ChartJS.register(CategoryScale, LinearScale, BarElement, Title, Tooltip, Legend)
 export default function YearlyDividendChart() {
     const [chartData, setChartData] = useState(null);
 
-    useEffect(() => {
-        fetch("http://localhost:8080/api/yearlyDividend", {
-            credentials: "include", // Cookieを送信（Spring Securityで認証する場合）
-        })
-            .then((res) => res.json())
-            .then((json) => {
-                setChartData({
-                    labels: json.labels.split(","), // サーバー側が文字列を返すならパース
-                    datasets: [
-                        {
-                            label: "配当受取額",
-                            data: JSON.parse(json.chartData), // 必要に応じてパース
-                            backgroundColor: "rgba(0, 0, 255, 0.5)",
-                        },
-                    ],
-                });
-            })
-            .catch((error) => {
-                console.error("Error parsing JSON:", error);
+useEffect(() => {
+    fetch("http://localhost:8080/api/yearlyDividend")
+        .then((res) => res.json())
+        .then((json) => {
+            setChartData({
+                labels: json.labels, // そのまま使用
+                datasets: [
+                    {
+                        label: "配当受取額",
+                        data: json.chartData, // そのまま使用
+                        backgroundColor: "rgba(0, 0, 255, 0.5)",
+                    },
+                ],
             });
-    }, []);
+        })
+        .catch((error) => {
+            console.error("Error parsing JSON:", error);
+        });
+}, []);
 
     if (!chartData) return <p>Loading...</p>;
 

--- a/frontend/src/app/yearlyDividend/page.tsx
+++ b/frontend/src/app/yearlyDividend/page.tsx
@@ -10,25 +10,25 @@ ChartJS.register(CategoryScale, LinearScale, BarElement, Title, Tooltip, Legend)
 export default function YearlyDividendChart() {
     const [chartData, setChartData] = useState(null);
 
-useEffect(() => {
-    fetch("http://localhost:8080/api/yearlyDividend")
-        .then((res) => res.json())
-        .then((json) => {
-            setChartData({
-                labels: json.labels,
-                datasets: [
-                    {
-                        label: "配当受取額",
-                        data: json.chartData,
-                        backgroundColor: "rgba(0, 0, 255, 0.5)",
-                    },
-                ],
+    useEffect(() => {
+        fetch("http://localhost:8080/api/yearlyDividend")
+            .then((res) => res.json())
+            .then((json) => {
+                setChartData({
+                    labels: json.labels,
+                    datasets: [
+                        {
+                            label: "配当受取額",
+                            data: json.chartData,
+                            backgroundColor: "rgba(0, 0, 255, 0.5)",
+                        },
+                    ],
+                });
+            })
+            .catch((error) => {
+                console.error("Error parsing JSON:", error);
             });
-        })
-        .catch((error) => {
-            console.error("Error parsing JSON:", error);
-        });
-}, []);
+    }, []);
 
     if (!chartData) return <p>Loading...</p>;
 

--- a/frontend/src/app/yearlyDividend/page.tsx
+++ b/frontend/src/app/yearlyDividend/page.tsx
@@ -17,6 +17,7 @@ interface ChartData {
 
 export default function YearlyDividendChart() {
     const [chartData, setChartData] = useState<ChartData | null>(null);
+    const [error, setError] = useState<string | null>(null);
 
     useEffect(() => {
         fetch("http://localhost:8080/api/yearlyDividend")
@@ -35,9 +36,11 @@ export default function YearlyDividendChart() {
             })
             .catch((error) => {
                 console.error("データ取得エラー:", error);
+                setError("データの取得に失敗しました");
             });
     }, []);
 
+    if (error) return <p className="text-red-500">{error}</p>;
     if (!chartData) return <p>Loading...</p>;
 
     return (

--- a/frontend/src/app/yearlyDividend/page.tsx
+++ b/frontend/src/app/yearlyDividend/page.tsx
@@ -3,7 +3,6 @@
 import { useEffect, useState } from "react";
 import { Chart as ChartJS, CategoryScale, LinearScale, BarElement, Title, Tooltip, Legend } from "chart.js";
 import { Chart } from "react-chartjs-2";
-import "chart.js/auto";
 
 ChartJS.register(CategoryScale, LinearScale, BarElement, Title, Tooltip, Legend);
 

--- a/frontend/src/app/yearlyDividend/page.tsx
+++ b/frontend/src/app/yearlyDividend/page.tsx
@@ -7,7 +7,7 @@ import { Chart } from "react-chartjs-2";
 ChartJS.register(CategoryScale, LinearScale, BarElement, Title, Tooltip, Legend);
 
 export default function YearlyDividendChart() {
-    const [chartData, setChartData] = useState(null);
+    const [chartData, setChartData] = useState({ labels: [], datasets: [] });
 
     useEffect(() => {
         fetch("http://localhost:8080/api/yearlyDividend")

--- a/frontend/src/app/yearlyDividend/page.tsx
+++ b/frontend/src/app/yearlyDividend/page.tsx
@@ -35,22 +35,26 @@ export default function YearlyDividendChart() {
         <div className="container mx-auto p-4">
             <h1 className="text-2xl font-bold mb-4">年別配当グラフ</h1>
             <div className="chart-container w-full h-96">
-                <Chart type="bar" data={chartData} options={{
-                    plugins: {
-                        title: {
-                            display: true,
-                            text: "年別配当受取額",
-                        },
-                    },
-                    scales: {
-                        y: {
-                            ticks: {
-                                callback: (value) => value + "ドル",
+                <Chart
+                    type="bar"
+                    data={chartData}
+                    options={{
+                        plugins: {
+                            title: {
+                                display: true,
+                                text: "年別配当受取額",
                             },
                         },
-                    },
-                    maintainAspectRatio: false,
-                }} />
+                        scales: {
+                            y: {
+                                ticks: {
+                                    callback: (value) => value + "ドル",
+                                },
+                            },
+                        },
+                        maintainAspectRatio: false,
+                    }}
+                />
             </div>
         </div>
     );

--- a/frontend/src/app/yearlyDividend/page.tsx
+++ b/frontend/src/app/yearlyDividend/page.tsx
@@ -6,6 +6,15 @@ import { Chart } from "react-chartjs-2";
 
 ChartJS.register(CategoryScale, LinearScale, BarElement, Title, Tooltip, Legend);
 
+interface ChartData {
+    labels: string[];
+    datasets: {
+        label: string;
+        data: number[];
+        backgroundColor: string;
+    }[];
+}
+
 export default function YearlyDividendChart() {
     const [chartData, setChartData] = useState({ labels: [], datasets: [] });
 

--- a/src/main/java/click/divichartnext/api/YearlyDividendApiController.java
+++ b/src/main/java/click/divichartnext/api/YearlyDividendApiController.java
@@ -37,7 +37,7 @@ public class YearlyDividendApiController {
 
         List<Integer> pastYears = service.getLastNYears(NUM_OF_YEARS);
         String labels = service.createYearLabels(pastYears);
-        List<BigDecimal> yearlyDividendData = service.getYearlyDividendData(pastYears, user.getUsername());
+        List<BigDecimal> yearlyDividendData = service.getYearlyDividendData(pastYears, "admin");//user.getUsername());
         String chartData = service.createChartData(yearlyDividendData);
 
         return new YearlyDividendDto(labels, chartData);

--- a/src/main/java/click/divichartnext/api/YearlyDividendApiController.java
+++ b/src/main/java/click/divichartnext/api/YearlyDividendApiController.java
@@ -40,6 +40,6 @@ public class YearlyDividendApiController {
         List<BigDecimal> yearlyDividendData = service.getYearlyDividendData(pastYears, "admin");//user.getUsername());
         String chartData = service.createChartData(yearlyDividendData);
 
-        return new YearlyDividendDto(labels, chartData);
+        return new YearlyDividendDto(pastYears, yearlyDividendData);
     }
 }

--- a/src/main/java/click/divichartnext/api/YearlyDividendApiController.java
+++ b/src/main/java/click/divichartnext/api/YearlyDividendApiController.java
@@ -1,0 +1,45 @@
+package click.divichartnext.api;
+
+import click.divichartnext.bean.dto.YearlyDividendDto;
+import click.divichartnext.service.YearlyDividendService;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.*;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+/**
+ * 年別配当データを提供するAPI
+ */
+@Slf4j
+@RestController
+@RequestMapping("/api/yearlyDividend")
+@CrossOrigin(origins = "http://localhost:3000") // Next.jsのURLに変更
+public class YearlyDividendApiController {
+    private static final int NUM_OF_YEARS = 5;
+
+    private final YearlyDividendService service;
+
+    @Autowired
+    public YearlyDividendApiController(YearlyDividendService yearlyDividendService) {
+        this.service = yearlyDividendService;
+    }
+
+    /**
+     * グラフ用のJSONデータを提供
+     */
+    @GetMapping
+    public YearlyDividendDto getYearlyDividend(@AuthenticationPrincipal UserDetails user) {
+        log.debug("年別配当データを取得");
+
+        List<Integer> pastYears = service.getLastNYears(NUM_OF_YEARS);
+        String labels = service.createYearLabels(pastYears);
+        List<BigDecimal> yearlyDividendData = service.getYearlyDividendData(pastYears, user.getUsername());
+        String chartData = service.createChartData(yearlyDividendData);
+
+        return new YearlyDividendDto(labels, chartData);
+    }
+}

--- a/src/main/java/click/divichartnext/bean/dto/YearlyDividendDto.java
+++ b/src/main/java/click/divichartnext/bean/dto/YearlyDividendDto.java
@@ -4,6 +4,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.io.Serializable;
+import java.math.BigDecimal;
+import java.util.List;
 
 /**
  * 年別配当グラフ画面用DTO
@@ -11,10 +13,10 @@ import java.io.Serializable;
 @Getter
 @NoArgsConstructor
 public class YearlyDividendDto implements Serializable {
-    private String labels;
-    private String chartData;
+    private List<Integer> labels;
+    private List<BigDecimal> chartData;
 
-    public YearlyDividendDto(String labels, String chartData) {
+    public YearlyDividendDto(List<Integer> labels, List<BigDecimal> chartData) {
         this.labels = labels;
         this.chartData = chartData;
     }

--- a/src/main/java/click/divichartnext/configuration/WebSecurityConfig.java
+++ b/src/main/java/click/divichartnext/configuration/WebSecurityConfig.java
@@ -35,6 +35,7 @@ public class WebSecurityConfig {
                                 mvcMatcherBuilder.pattern("/"),
                                 mvcMatcherBuilder.pattern("/login"),
                                 mvcMatcherBuilder.pattern("/css/**"),
+                                mvcMatcherBuilder.pattern("/api/**"),
                                 mvcMatcherBuilder.pattern("/createUserAccount/**"),
                                 mvcMatcherBuilder.pattern("/lp")
                         ).permitAll()
@@ -61,7 +62,8 @@ public class WebSecurityConfig {
         // h2-consoleを表示するためにCSRF対策外へ指定
         http.csrf(csrf ->
                 csrf.ignoringRequestMatchers(
-                        AntPathRequestMatcher.antMatcher("/h2-console/**")
+                        AntPathRequestMatcher.antMatcher("/h2-console/**"),
+                        AntPathRequestMatcher.antMatcher("/api/**") // 追加: /api/loginのCSRF対策を無効にする
                 )
         );
 

--- a/src/main/java/click/divichartnext/controller/YearlyDividendController.java
+++ b/src/main/java/click/divichartnext/controller/YearlyDividendController.java
@@ -35,19 +35,20 @@ public class YearlyDividendController {
      */
     @GetMapping
     public String index(Model model, @AuthenticationPrincipal UserDetails user) {
-        log.debug("年別配当グラフ表示");
-
-        List<Integer> pastYears = service.getLastNYears(NUM_OF_YEARS);
-        String labels = service.createYearLabels(pastYears);
-        List<BigDecimal> yearlyDividendData = service.getYearlyDividendData(pastYears, user.getUsername());
-        String chartData = service.createChartData(yearlyDividendData);
-
-        YearlyDividendDto yearlyDividendDto = new YearlyDividendDto(
-                labels,
-                chartData
-        );
-        model.addAttribute("yearlyDividendDto", yearlyDividendDto);
-
-        return "yearlyDividend";
+//        log.debug("年別配当グラフ表示");
+//
+//        List<Integer> pastYears = service.getLastNYears(NUM_OF_YEARS);
+//        String labels = service.createYearLabels(pastYears);
+//        List<BigDecimal> yearlyDividendData = service.getYearlyDividendData(pastYears, user.getUsername());
+//        String chartData = service.createChartData(yearlyDividendData);
+//
+//        YearlyDividendDto yearlyDividendDto = new YearlyDividendDto(
+//                labels,
+//                chartData
+//        );
+//        model.addAttribute("yearlyDividendDto", yearlyDividendDto);
+//
+//        return "yearlyDividend";
+        return null;
     }
 }


### PR DESCRIPTION
# 内容

- 年別配当グラフの REST API を追加
- 認証を入れたかったが上手くいかないため取敢えずskip
  - のちほど対応する
- 旧Controllerは後程消す


